### PR TITLE
Popular produce fix

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -456,7 +456,7 @@ body {
 }
 
 /* Section Title Styling */
-.section-title {
+.popular-produce .section-title {
     font-size: 36px;
     text-align: left;
     font-family: 'Arimo', sans-serif;


### PR DESCRIPTION
I fixed the popular produce title margins in the css by being more specific with the targeting: .popular-produce .section-title

This ensures the css styling for this section dont have a conflict with other sections.